### PR TITLE
CI: fix macOS test launch + DinkyPDFSignals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# Build + unit tests on every PR and on main. Pair with branch protection:
+# Settings → Branches → Add rule for `main` → require this check, require PR.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test
+        run: |
+          set -eo pipefail
+          xcodebuild \
+            -project Dinky.xcodeproj \
+            -scheme Dinky \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ concurrency:
 
 jobs:
   macos:
-    runs-on: macos-15
+    # macOS 26 + Xcode 26 (e.g. SwiftUI `.glassEffect()`); macos-15 images only ship Xcode 16.x.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # Build + unit tests on every PR and on main. Pair with branch protection:
 # Settings → Branches → Add rule for `main` → require this check, require PR.
+# Do not pass CODE_SIGNING_ALLOWED=NO — macOS test bundles need ad-hoc signing to launch.
 
 name: CI
 
@@ -28,5 +29,4 @@ jobs:
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
             test

--- a/Dinky.xcodeproj/project.pbxproj
+++ b/Dinky.xcodeproj/project.pbxproj
@@ -79,6 +79,10 @@
 		OP000001000000000000001 /* OutputPathUniqueness.swift in Sources */ = {isa = PBXBuildFile; fileRef = OP100001000000000000001 /* OutputPathUniqueness.swift */; };
 		SP000001000000000000001 /* SavingsPerspective.swift in Sources */ = {isa = PBXBuildFile; fileRef = SP100001000000000000001 /* SavingsPerspective.swift */; };
 		XTBLD00000000000000001 /* PDFScanDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = XTREF00000000000000001 /* PDFScanDetectionTests.swift */; };
+		PSFBLD0000000000000001 /* PDFScanSignals.swift in Sources */ = {isa = PBXBuildFile; fileRef = PSFILE000000000000001 /* PDFScanSignals.swift */; };
+		PSFBLD0000000000000002 /* DinkyPDFSignals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PSPRD00000000000000001 /* DinkyPDFSignals.framework */; };
+		PSFBLD0000000000000003 /* DinkyPDFSignals.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = PSPRD00000000000000001 /* DinkyPDFSignals.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		PSFBLD0000000000000004 /* DinkyPDFSignals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = PSPRD00000000000000001 /* DinkyPDFSignals.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -192,6 +196,8 @@
 		SP100001000000000000001 /* SavingsPerspective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavingsPerspective.swift; sourceTree = "<group>"; };
 		XTREF00000000000000001 /* PDFScanDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFScanDetectionTests.swift; sourceTree = "<group>"; };
 		XTPRD00000000000000001 /* DinkyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DinkyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		PSPRD00000000000000001 /* DinkyPDFSignals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DinkyPDFSignals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		PSFILE000000000000001 /* PDFScanSignals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFScanSignals.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,10 +205,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				PSFBLD0000000000000002 /* DinkyPDFSignals.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		XTFR00000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				PSFBLD0000000000000004 /* DinkyPDFSignals.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		PSFRM00000000000000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -293,6 +308,7 @@
 		3337D9E5CCB647BAA20571DE /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				PSPRD00000000000000001 /* DinkyPDFSignals.framework */,
 				06FD4F8D9AC8412C83F517C6 /* Dinky.app */,
 				XTPRD00000000000000001 /* DinkyTests.xctest */,
 			);
@@ -308,6 +324,14 @@
 				ASH10001000000000000001 /* DinkyAppShortcuts.swift */,
 			);
 			path = Intents;
+			sourceTree = "<group>";
+		};
+		PSGGRP00000000000000001 /* DinkyPDFSignals */ = {
+			isa = PBXGroup;
+			children = (
+				PSFILE000000000000001 /* PDFScanSignals.swift */,
+			);
+			path = DinkyPDFSignals;
 			sourceTree = "<group>";
 		};
 		4E72C0A5F2794B39AD3A51DF /* Dinky */ = {
@@ -349,6 +373,7 @@
 			isa = PBXGroup;
 			children = (
 				4E72C0A5F2794B39AD3A51DF /* Dinky */,
+				PSGGRP00000000000000001 /* DinkyPDFSignals */,
 				XTGRP00000000000000001 /* DinkyTests */,
 				AI100001000000000000001 /* AppIcon.icon */,
 				3337D9E5CCB647BAA20571DE /* Products */,
@@ -386,15 +411,33 @@
 				E21DF18078534E6AAFC3CD56 /* Frameworks */,
 				E3643529CC4842C6B993EE52 /* Resources */,
 				RS000001000000000000001 /* Re-sign bundled binaries */,
+				PSCOPY00000000000000001 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				PSTTD00000000000000001 /* PBXTargetDependency */,
 			);
 			name = Dinky;
 			productName = Dinky;
 			productReference = 06FD4F8D9AC8412C83F517C6 /* Dinky.app */;
 			productType = "com.apple.product-type.application";
+		};
+		PSGT00000000000000001 /* DinkyPDFSignals */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = PSSCL00000000000000001 /* Build configuration list for PBXNativeTarget "DinkyPDFSignals" */;
+			buildPhases = (
+				PSSRC00000000000000001 /* Sources */,
+				PSFRM00000000000000001 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DinkyPDFSignals;
+			productName = DinkyPDFSignals;
+			productReference = PSPRD00000000000000001 /* DinkyPDFSignals.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		XTGT00000000000000001 /* DinkyTests */ = {
 			isa = PBXNativeTarget;
@@ -406,7 +449,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				XTTD00000000000000001 /* PBXTargetDependency */,
+				PSTTD00000000000000002 /* PBXTargetDependency */,
 			);
 			name = DinkyTests;
 			productName = DinkyTests;
@@ -416,20 +459,32 @@
 /* End PBXNativeTarget section */
 
 /* Begin PBXContainerItemProxy section */
-		XTCP00000000000000001 /* PBXContainerItemProxy */ = {
+		PSTCP00000000000000001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 30998CF249484469BEA4BC05 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1224039F8B5340EE9F91589E /* Dinky */;
-			remoteInfo = Dinky;
+			remoteGlobalIDString = PSGT00000000000000001 /* DinkyPDFSignals */;
+			remoteInfo = DinkyPDFSignals;
+		};
+		PSTCP00000000000000002 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 30998CF249484469BEA4BC05 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = PSGT00000000000000001 /* DinkyPDFSignals */;
+			remoteInfo = DinkyPDFSignals;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXTargetDependency section */
-		XTTD00000000000000001 /* PBXTargetDependency */ = {
+		PSTTD00000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 1224039F8B5340EE9F91589E /* Dinky */;
-			targetProxy = XTCP00000000000000001 /* PBXContainerItemProxy */;
+			target = PSGT00000000000000001 /* DinkyPDFSignals */;
+			targetProxy = PSTCP00000000000000001 /* PBXContainerItemProxy */;
+		};
+		PSTTD00000000000000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = PSGT00000000000000001 /* DinkyPDFSignals */;
+			targetProxy = PSTCP00000000000000002 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -471,6 +526,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				PSGT00000000000000001 /* DinkyPDFSignals */,
 				1224039F8B5340EE9F91589E /* Dinky */,
 				XTGT00000000000000001 /* DinkyTests */,
 			);
@@ -497,6 +553,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		PSCOPY00000000000000001 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				PSFBLD0000000000000003 /* DinkyPDFSignals.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		998A23993F5848F1B732DC47 /* Sources */ = {
@@ -571,6 +641,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				XTBLD00000000000000001 /* PDFScanDetectionTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		PSSRC00000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				PSFBLD0000000000000001 /* PDFScanSignals.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -778,7 +856,6 @@
 		XTBCFGD000000000000001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -789,14 +866,12 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dinky.app/Contents/MacOS/Dinky";
 			};
 			name = Debug;
 		};
 		XTBCFGR000000000000001 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -807,7 +882,62 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dinky.app/Contents/MacOS/Dinky";
+			};
+			name = Release;
+		};
+		PSSBCFGD000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dinky.app.DinkyPDFSignals;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		PSSBCFGR000000000000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dinky.app.DinkyPDFSignals;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};
@@ -837,6 +967,15 @@
 			buildConfigurations = (
 				XTBCFGD000000000000001 /* Debug */,
 				XTBCFGR000000000000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		PSSCL00000000000000001 /* Build configuration list for PBXNativeTarget "DinkyPDFSignals" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				PSSBCFGD000000000000001 /* Debug */,
+				PSSBCFGR000000000000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Dinky.xcodeproj/xcshareddata/xcschemes/Dinky.xcscheme
+++ b/Dinky.xcodeproj/xcshareddata/xcschemes/Dinky.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1224039F8B5340EE9F91589E"
+               BuildableName = "Dinky.app"
+               BlueprintName = "Dinky"
+               ReferencedContainer = "container:Dinky.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XTGT00000000000000001"
+               BuildableName = "DinkyTests.xctest"
+               BlueprintName = "DinkyTests"
+               ReferencedContainer = "container:Dinky.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1224039F8B5340EE9F91589E"
+            BuildableName = "Dinky.app"
+            BlueprintName = "Dinky"
+            ReferencedContainer = "container:Dinky.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1224039F8B5340EE9F91589E"
+            BuildableName = "Dinky.app"
+            BlueprintName = "Dinky"
+            ReferencedContainer = "container:Dinky.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Dinky/ContentView.swift
+++ b/Dinky/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DinkyPDFSignals
 import UniformTypeIdentifiers
 import UserNotifications
 import Darwin

--- a/Dinky/Intents/CompressPDFIntent.swift
+++ b/Dinky/Intents/CompressPDFIntent.swift
@@ -1,4 +1,5 @@
 import AppIntents
+import DinkyPDFSignals
 import Foundation
 
 struct CompressPDFIntent: AppIntent {

--- a/Dinky/Services/PDFDocumentSampler.swift
+++ b/Dinky/Services/PDFDocumentSampler.swift
@@ -1,53 +1,8 @@
 import Foundation
+import DinkyPDFSignals
 import PDFKit
 import CoreGraphics
 import AppKit
-
-/// Threshold on ``PDFDocumentSignals/scanLikelihood`` to treat a document as scan-like for OCR.
-enum PDFScanDetection {
-    static let ocrLikelihoodThreshold: Double = 0.42
-}
-
-/// Cheap signals from a quick PDF sample (same page indices as flatten Smart Quality).
-struct PDFDocumentSignals: Sendable {
-    let pageCount: Int
-    let bytesPerPage: Double
-    let avgChromaSpread: Double
-    let avgNonWhiteFill: Double
-    /// Sum of `PDFPage.string` lengths on sampled pages (text density hint).
-    let totalTextCharsSampled: Int
-
-    /// 0...1 — image-heavy / low extractable text vs born-digital text; includes color scans (not just mono).
-    var scanLikelihood: Double {
-        guard pageCount > 0 else { return 0 }
-        let sampled = min(5, pageCount)
-        let avgChars = Double(totalTextCharsSampled) / Double(max(1, sampled))
-        if avgChars > 120 { return 0 }
-        if avgChars > 50 { return 0.08 }
-        let bpp = bytesPerPage
-        if bpp < 12_000 { return min(0.15, 1.0 - avgChars / 80.0) }
-        if bpp > 4_000_000 { return 0.22 }
-        let textEmpty = min(1.0, 1.0 - avgChars / 45.0)
-        let densityCue = min(1.0, (bpp - 12_000) / 1_100_000)
-        let colorBoost = avgChromaSpread > 0.02 ? 0.22 : 0.05
-        let monoBoost = monochromeScanLikelihood >= 0.35 ? 0.18 : 0
-        return min(1.0, textEmpty * (0.42 + 0.48 * densityCue) + colorBoost + monoBoost)
-    }
-
-    /// 0...1 — likely office / fax-style monochrome scan (flatten path may auto-grayscale).
-    var monochromeScanLikelihood: Double {
-        guard pageCount > 0 else { return 0 }
-        // Typical camera scans and color docs have meaningful chroma; B&W text scans do not.
-        if avgChromaSpread > 0.022 { return 0 }
-        let bpp = bytesPerPage
-        if bpp < 35_000 || bpp > 1_200_000 { return 0 }
-        // Heavy ink coverage or very empty pages — both common in scans.
-        let extremeFill = avgNonWhiteFill < 0.06 || avgNonWhiteFill > 0.88
-        if extremeFill { return min(1, 0.55 + (0.022 - avgChromaSpread) * 12) }
-        if avgNonWhiteFill < 0.12, avgChromaSpread < 0.015 { return 0.45 }
-        return 0
-    }
-}
 
 /// Shared PDF page sampling for Smart Quality flatten, preserve heuristics, and mono detection.
 enum PDFDocumentSampler {

--- a/Dinky/Services/PDFPreserveHeuristics.swift
+++ b/Dinky/Services/PDFPreserveHeuristics.swift
@@ -1,3 +1,4 @@
+import DinkyPDFSignals
 import Foundation
 
 /// One qpdf attempt on the preserve path (`extraArgs` append after base `--optimize-images` args).

--- a/Dinky/Services/PDFSmartQuality.swift
+++ b/Dinky/Services/PDFSmartQuality.swift
@@ -1,4 +1,5 @@
 import Foundation
+import DinkyPDFSignals
 import PDFKit
 import CoreGraphics
 import AppKit

--- a/DinkyPDFSignals/PDFScanSignals.swift
+++ b/DinkyPDFSignals/PDFScanSignals.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Threshold on ``PDFDocumentSignals/scanLikelihood`` to treat a document as scan-like for OCR.
+public enum PDFScanDetection {
+    public static let ocrLikelihoodThreshold: Double = 0.42
+}
+
+/// Cheap signals from a quick PDF sample (same page indices as flatten Smart Quality).
+public struct PDFDocumentSignals: Sendable {
+    public let pageCount: Int
+    public let bytesPerPage: Double
+    public let avgChromaSpread: Double
+    public let avgNonWhiteFill: Double
+    /// Sum of `PDFPage.string` lengths on sampled pages (text density hint).
+    public let totalTextCharsSampled: Int
+
+    public init(
+        pageCount: Int,
+        bytesPerPage: Double,
+        avgChromaSpread: Double,
+        avgNonWhiteFill: Double,
+        totalTextCharsSampled: Int
+    ) {
+        self.pageCount = pageCount
+        self.bytesPerPage = bytesPerPage
+        self.avgChromaSpread = avgChromaSpread
+        self.avgNonWhiteFill = avgNonWhiteFill
+        self.totalTextCharsSampled = totalTextCharsSampled
+    }
+
+    /// 0...1 — image-heavy / low extractable text vs born-digital text; includes color scans (not just mono).
+    public var scanLikelihood: Double {
+        guard pageCount > 0 else { return 0 }
+        let sampled = min(5, pageCount)
+        let avgChars = Double(totalTextCharsSampled) / Double(max(1, sampled))
+        if avgChars > 120 { return 0 }
+        if avgChars > 50 { return 0.08 }
+        let bpp = bytesPerPage
+        if bpp < 12_000 { return min(0.15, 1.0 - avgChars / 80.0) }
+        if bpp > 4_000_000 { return 0.22 }
+        let textEmpty = min(1.0, 1.0 - avgChars / 45.0)
+        let densityCue = min(1.0, (bpp - 12_000) / 1_100_000)
+        let colorBoost = avgChromaSpread > 0.02 ? 0.22 : 0.05
+        let monoBoost = monochromeScanLikelihood >= 0.35 ? 0.18 : 0
+        return min(1.0, textEmpty * (0.42 + 0.48 * densityCue) + colorBoost + monoBoost)
+    }
+
+    /// 0...1 — likely office / fax-style monochrome scan (flatten path may auto-grayscale).
+    public var monochromeScanLikelihood: Double {
+        guard pageCount > 0 else { return 0 }
+        // Typical camera scans and color docs have meaningful chroma; B&W text scans do not.
+        if avgChromaSpread > 0.022 { return 0 }
+        let bpp = bytesPerPage
+        if bpp < 35_000 || bpp > 1_200_000 { return 0 }
+        // Heavy ink coverage or very empty pages — both common in scans.
+        let extremeFill = avgNonWhiteFill < 0.06 || avgNonWhiteFill > 0.88
+        if extremeFill { return min(1, 0.55 + (0.022 - avgChromaSpread) * 12) }
+        if avgNonWhiteFill < 0.12, avgChromaSpread < 0.015 { return 0.45 }
+        return 0
+    }
+}

--- a/DinkyTests/PDFScanDetectionTests.swift
+++ b/DinkyTests/PDFScanDetectionTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Dinky
+import DinkyPDFSignals
 
 final class PDFScanDetectionTests: XCTestCase {
 


### PR DESCRIPTION
This PR delivers the CI workflow (if not yet on `main`) and fixes `xcodebuild test` on macOS runners.

**Changes**
- Add `DinkyPDFSignals` (embedded framework) with PDF scan likelihood types so `DinkyTests` runs as a normal bundle without `TEST_HOST` / `BUNDLE_LOADER`.
- Remove `CODE_SIGNING_ALLOWED=NO` from the workflow so ad-hoc signing allows Launch Services to run tests.
- Document that signing flag in a workflow comment.

**Verified**
- `xcodebuild -project Dinky.xcodeproj -scheme Dinky -configuration Debug -destination 'platform=macOS' CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO test` passes locally.

After merge: enable branch protection on `main` and require the **CI** check (job `macos`; status name is typically `CI / macos`).

Made with [Cursor](https://cursor.com)