### PR TITLE
docs: CLI + local API in README, site, FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Hey! I'm [Derek Castelli](https://www.heyderekj.com), a full-time freelance web 
 - **Session history** — review past compression sessions with file counts and total bytes saved
 - **Apple Shortcuts** — compress images from automations via a native Shortcuts action
 - **Custom keyboard shortcuts** — rebind Open Files, Clipboard Compress, Compress Now, Clear, and Delete in Settings → Shortcuts
+- **CLI + local API (pro users)** — optional `dinky` CLI and local `dinky serve` endpoint for scripts and AI-agent workflows (`--json` output, loopback/local use)
 - **Launch at login** — opt in once and Dinky's ready the moment you log in (handy alongside Watch Folders for set-and-forget compression)
 - **Easy updating** — one click checks for a new release, installs, and relaunches; no browser, no re-drag
 - **Skip threshold** — skip files below a minimum savings target: Off, 2%, 5%, or 10%
@@ -145,3 +146,18 @@ mdfind 'kMDItemCFBundleIdentifier == "com.dinky.app"'
 ```
 
 Delete or move any extra `Dinky.app` you do not need (for example an old one left in Downloads). Log out and back in if the menu still looks stale.
+
+### How do I access the CLI or use Dinky with AI agents?
+
+Use the optional local package in this repo:
+
+```bash
+cd DinkyCoreImage
+swift build -c release
+./.build/release/dinky --help
+```
+
+- One-shot automation: run `dinky compress ... --json`
+- Repeated automation/agents: run `dinky serve --port 17381` and call `127.0.0.1` endpoints
+
+See [docs/local-cli.md](docs/local-cli.md) for commands, JSON schemas, and examples.

--- a/site/homepage.md
+++ b/site/homepage.md
@@ -23,6 +23,7 @@ A tiny macOS app that shrinks images, videos, and PDFs. Drag, drop, get smaller 
 - **Watch folder** — auto-compress files dropped into a watched folder
 - **Originals** — keep, move to Trash, or move to a Backup folder per preset
 - **Custom keyboard shortcuts** — rebind Open Files, Clipboard Compress, Compress Now, Clear, and Delete
+- **CLI + local API (pro users)** — optional `dinky` CLI and `dinky serve` loopback endpoint for scripts and AI agents
 - **Launch at login** — opt in once and Dinky's ready when you log in
 - **Speaks 12 languages** — German, Spanish, French, Italian, Japanese, Korean, Dutch, Brazilian Portuguese, Russian, Turkish, Simplified Chinese, Traditional Chinese
 - **Presets**, **before/after preview**, **Finder Quick Actions**, **in-app updates**

--- a/site/index.html
+++ b/site/index.html
@@ -1810,8 +1810,8 @@
       <svg class="feature-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M2.25 5.25a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V5.25Zm3.97.97a.75.75 0 0 1 1.06 0l2.25 2.25a.75.75 0 0 1 0 1.06l-2.25 2.25a.75.75 0 0 1-1.06-1.06l1.72-1.72-1.72-1.72a.75.75 0 0 1 0-1.06Zm4.28 4.28a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 0-1.5h-3Z" clip-rule="evenodd"/>
       </svg>
-      <h3>Custom shortcuts</h3>
-      <p>Rebind Open Files, Clipboard Compress, Compress Now, Clear, and Delete in Settings → Shortcuts.</p>
+      <h3>CLI + local API</h3>
+      <p>Pro users can run <code>dinky compress --json</code> or keep <code>dinky serve</code> running on loopback for scripts and AI agents.</p>
     </div>
 
         <div class="feature">
@@ -2102,6 +2102,11 @@
       <div class="faq-item">
         <h3 class="faq-q">Does Dinky send my files anywhere?</h3>
         <p class="faq-a">Nope. Everything runs locally on your Mac. Your files never leave your machine — no servers, no accounts, no uploads.</p>
+      </div>
+
+      <div class="faq-item">
+        <h3 class="faq-q">Can I use Dinky from Terminal or AI agents?</h3>
+        <p class="faq-a">Yep — pro users can build the local <code>dinky</code> CLI from this repo and run <code>dinky compress --json</code> or <code>dinky serve</code> on <code>127.0.0.1</code>. See <a href="https://github.com/heyderekj/dinky/blob/main/docs/local-cli.md" target="_blank" rel="noopener">local CLI docs</a> for examples and schema details.</p>
       </div>
 
       <div class="faq-item">


### PR DESCRIPTION
Follow-up to v2.8.0: document the optional `dinky` CLI and `dinky serve` in README, homepage copy, and site FAQ, with link to docs/local-cli.md.

Made with [Cursor](https://cursor.com)