### PR TITLE
Fix deprecated `depends_on macos:` syntax in dinky.rb

### DIFF
--- a/Casks/dinky.rb
+++ b/Casks/dinky.rb
@@ -7,7 +7,7 @@ cask "dinky" do
   desc "Image, video, audio, and PDF compression utility"
   homepage "https://github.com/heyderekj/dinky"
 
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "Dinky.app"
 end


### PR DESCRIPTION
Calling string comparison format for `depends_on macos:` is deprecated in the latest Homebrew. They suggested using `depends_on macos: :sequoia` instead.